### PR TITLE
Eval

### DIFF
--- a/eval_attn_image.sh
+++ b/eval_attn_image.sh
@@ -20,4 +20,4 @@ rm -rf /opt/project/pytorch-CycleGAN-and-pix2pix/results/color_pix2pix/attn_late
 # Calculate FID
 cd /opt/pytorch-fid/
 python fid_score.py /opt/project/pytorch-CycleGAN-and-pix2pix/datasets/bird/train\
- /opt/project/pytorch-CycleGAN-and-pix2pix/results/color_pix2pix/attn_latest/fake_images
+ /opt/project/pytorch-CycleGAN-and-pix2pix/results/color_pix2pix/attn_latest/fake_images -c 0

--- a/eval_attn_image.sh
+++ b/eval_attn_image.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Prepare AttnGAN image for pix2pix
+python preprocess_attn_image.py\
+ --attn_data ../AttnGAN/output/birds_attn2_2019_07_25_10_29_58/Model/netG_epoch_550/valid/single
+
+# Colorization
+python test.py --dataroot ./datasets/bird --name color_pix2pix --model colorization\
+ --phase attn --name color_pix2pix --gpu_id 0 --num_test 30000
+
+# Prepare for fid_score
+mkdir ./datasets/bird/attn/fake_images
+for i in `seq 0 9`
+do
+ cp /opt/project/pytorch-CycleGAN-and-pix2pix/results/color_pix2pix/attn_latest/images/${i}*_fake*\
+  /opt/project/pytorch-CycleGAN-and-pix2pix/results/color_pix2pix/attn_latest/fake_images/
+done
+rm -rf /opt/project/pytorch-CycleGAN-and-pix2pix/results/color_pix2pix/attn_latest/images
+
+# Calculate FID
+cd /opt/pytorch-fid/
+python fid_score.py /opt/project/pytorch-CycleGAN-and-pix2pix/datasets/bird/train\
+ /opt/project/pytorch-CycleGAN-and-pix2pix/results/color_pix2pix/attn_latest/fake_images

--- a/eval_attn_image.sh
+++ b/eval_attn_image.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Prepare AttnGAN image for pix2pix
-python preprocess_attn_image.py\
+python preprocess_attnimage.py\
  --attn_data ../AttnGAN/output/birds_attn2_2019_07_25_10_29_58/Model/netG_epoch_550/valid/single
 
 # Colorization

--- a/options/test_options.py
+++ b/options/test_options.py
@@ -13,11 +13,14 @@ class TestOptions(BaseOptions):
         parser.add_argument('--results_dir', type=str, default='./results/', help='saves results here.')
         parser.add_argument('--aspect_ratio', type=float, default=1.0, help='aspect ratio of result images')
         parser.add_argument('--phase', type=str, default='test', help='train, val, test, etc')
+        parser.add_argument('--random_sample', dest="serial_batches", action='store_false',
+                            help='results on randomly chosen images')
         # Dropout and Batchnorm has different behavioir during training and test.
         parser.add_argument('--eval', action='store_true', help='use eval mode during test time.')
         parser.add_argument('--num_test', type=int, default=50, help='how many test images to run')
         # rewrite devalue values
         parser.set_defaults(model='test')
+        parser.set_defaults(serial_batches=True)
         # To avoid cropping, the load_size should be the same as crop_size
         parser.set_defaults(load_size=parser.get_default('crop_size'))
         self.isTrain = False

--- a/preprocess_attnimage.py
+++ b/preprocess_attnimage.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+import argparse
+import pickle
+import os
+import subprocess
+from miscc.utils import mkdir_p
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--filename_info", type=str,
+                        default='../AttnGAN/data/birds/test/filenames.pickle')
+    parser.add_argument("--attn_data", type=str,
+                        default="../AttnGAN/output/birds_attn2_2019_07_25_10_29_58/Model/netG_epoch_600/valid/single")
+    parser.add_argument("--output", type=str,
+                        default="./datasets/bird/attn")
+    parser.add_argument("--captions_per_image", type=int, default=10)
+    opt = parser.parse_args()
+
+    with open(opt.filename_info, "rb") as f:
+        filename_info = pickle.load(f)
+        print("Load from:", opt.filename_info)
+
+    if not os.path.isdir(opt.output):
+        print('Make a new folder: ', opt.output)
+        mkdir_p(folder)
+
+    serialized_index = 0
+    for f_info in filename_info:
+        for index in range(opt.captions_per_image):
+            filename = os.path.join(opt.attn_data, "{}_s-1_sent{}.jpg".format(f_info, index))
+            assert os.path.isfile(filename), "ERROR: invelid file name {}".format(filename)
+            output = os.path.join(opt.output, "{}.jpg".format(serialized_index))
+            serialized_index += 1
+            exit_code = subprocess.check_call(["cp", filename, output])
+            assert exit_code == 0,\
+                "ERROR: cp process failed. code({}). cp from {}, to {}".format(exit_code, filename, output)

--- a/preprocess_attnimage.py
+++ b/preprocess_attnimage.py
@@ -14,7 +14,8 @@ if __name__ == '__main__':
                         default="../AttnGAN/output/birds_attn2_2019_07_25_10_29_58/Model/netG_epoch_600/valid/single")
     parser.add_argument("--output", type=str,
                         default="./datasets/bird/attn")
-    parser.add_argument("--captions_per_image", type=int, default=10)
+    parser.add_argument("--captions_per_image", type=int,
+                        default=10)
     opt = parser.parse_args()
 
     with open(opt.filename_info, "rb") as f:
@@ -23,7 +24,7 @@ if __name__ == '__main__':
 
     if not os.path.isdir(opt.output):
         print('Make a new folder: ', opt.output)
-        mkdir_p(folder)
+        mkdir_p(opt.output)
 
     serialized_index = 0
     for f_info in filename_info:
@@ -32,6 +33,13 @@ if __name__ == '__main__':
             assert os.path.isfile(filename), "ERROR: invelid file name {}".format(filename)
             output = os.path.join(opt.output, "{}.jpg".format(serialized_index))
             serialized_index += 1
+
+            # print progress
+            if serialized_index % 1000 == 0:
+                print("step:", serialized_index)
+
             exit_code = subprocess.check_call(["cp", filename, output])
             assert exit_code == 0,\
                 "ERROR: cp process failed. code({}). cp from {}, to {}".format(exit_code, filename, output)
+    print("Finish: process {} images".format(serialized_index))
+

--- a/test.py
+++ b/test.py
@@ -39,7 +39,6 @@ if __name__ == '__main__':
     # hard-code some parameters for test
     opt.num_threads = 0   # test code only supports num_threads = 1
     opt.batch_size = 1    # test code only supports batch_size = 1
-    opt.serial_batches = True  # disable data shuffling; comment this line if results on randomly chosen images are needed.
     opt.no_flip = True    # no flip; comment this line if results on flipped images are needed.
     opt.display_id = -1   # no visdom display; the test code saves the results to a HTML file.
     opt.captions_per_image = 1

--- a/test.py
+++ b/test.py
@@ -30,7 +30,7 @@ import os
 from options.test_options import TestOptions
 from data import create_dataset
 from models import create_model
-from util.visualizer import save_images
+from util.visualizer import save_caption_images
 from util import html
 
 
@@ -42,12 +42,14 @@ if __name__ == '__main__':
     opt.serial_batches = True  # disable data shuffling; comment this line if results on randomly chosen images are needed.
     opt.no_flip = True    # no flip; comment this line if results on flipped images are needed.
     opt.display_id = -1   # no visdom display; the test code saves the results to a HTML file.
+    opt.captions_per_image = 1
     dataset = create_dataset(opt)  # create a dataset given opt.dataset_mode and other options
     model = create_model(opt)      # create a model given opt.model and other options
     model.setup(opt)               # regular setup: load and print networks; create schedulers
     # create a website
     web_dir = os.path.join(opt.results_dir, opt.name, '%s_%s' % (opt.phase, opt.epoch))  # define the website directory
     webpage = html.HTML(web_dir, 'Experiment = %s, Phase = %s, Epoch = %s' % (opt.name, opt.phase, opt.epoch))
+    system_word_ix = dataset.dataset.wordtoix["<end>"]
     # test with eval mode. This only affects layers like batchnorm and dropout.
     # For [pix2pix]: we use batchnorm and dropout in the original pix2pix. You can experiment it with and without eval() mode.
     # For [CycleGAN]: It should not affect CycleGAN as CycleGAN uses instancenorm without dropout.
@@ -60,7 +62,10 @@ if __name__ == '__main__':
         model.test()           # run inference
         visuals = model.get_current_visuals()  # get image results
         img_path = model.get_image_paths()     # get image paths
+        str_caption = " ".join(
+            [dataset.dataset.ixtoword[cap] for cap in model.caption[0].tolist() if cap != system_word_ix])
         if i % 5 == 0:  # save images to an HTML file
             print('processing (%04d)-th image... %s' % (i, img_path))
-        save_images(webpage, visuals, img_path, aspect_ratio=opt.aspect_ratio, width=opt.display_winsize)
+        save_caption_images(webpage, visuals, img_path, str_caption,
+                            aspect_ratio=opt.aspect_ratio, width=opt.display_winsize)
     webpage.save()  # save the HTML

--- a/util/visualizer.py
+++ b/util/visualizer.py
@@ -49,6 +49,43 @@ def save_images(webpage, visuals, image_path, aspect_ratio=1.0, width=256):
     webpage.add_images(ims, txts, links, width=width)
 
 
+def save_caption_images(webpage, visuals, image_path, caption, aspect_ratio=1.0, width=256):
+    """Save images to the disk.
+
+    Parameters:
+        webpage (the HTML class) -- the HTML webpage class that stores these imaegs (see html.py for more details)
+        visuals (OrderedDict)    -- an ordered dictionary that stores (name, images (either tensor or numpy) ) pairs
+        image_path (str)         -- the string is used to create image paths
+        caption (str)            -- the caption corresponding to the image
+        aspect_ratio (float)     -- the aspect ratio of saved images
+        width (int)              -- the images will be resized to width x width
+
+    This function will save images stored in 'visuals' to the HTML file specified by 'webpage'.
+    """
+    image_dir = webpage.get_image_dir()
+    short_path = ntpath.basename(image_path[0])
+    name = os.path.splitext(short_path)[0]
+
+    webpage.add_header("{}: {}".format(name, caption))
+    ims, txts, links = [], [], []
+
+    for label, im_data in visuals.items():
+        im = util.tensor2im(im_data)
+        image_name = '%s_%s.png' % (name, label)
+        save_path = os.path.join(image_dir, image_name)
+        h, w, _ = im.shape
+        if aspect_ratio > 1.0:
+            im = imresize(im, (h, int(w * aspect_ratio)), interp='bicubic')
+        if aspect_ratio < 1.0:
+            im = imresize(im, (int(h / aspect_ratio), w), interp='bicubic')
+        util.save_image(im, save_path)
+
+        ims.append(image_name)
+        txts.append(label)
+        links.append(image_name)
+    webpage.add_images(ims, txts, links, width=width)
+
+
 class Visualizer():
     """This class includes several functions that can display/save images and print/save logging information.
 


### PR DESCRIPTION
白黒画像生成からの着色の評価に関する変更
* AttnGAN で生成した白黒画像を pix2pix で利用しやすいようにフォルダ構造を調整 (preprocess_attnimages.py)
* test.py のオプションを調整
  * 1 キャプション 1 画像
  * スコア算出用に全てのテストデータについて着色を行う場合と，生成例を見るためにランダムにサンプルして着色する場合とで分けれるように，opt.serial_batches をコマンドライン引数から指定できるようにした (--random_sample option)
* index.html に入力キャプションが表示されるようにした
* AttnGAN 生成された状態から FID を算出するところまでの一連を行う bash スクリプトを書いた (eval_attn_image.sh)

## やること
以下ができたらマージする．
- [x] test.py でランダムな時に取ってくる入力キャプションがずれていそうな原因を探る．